### PR TITLE
Updating websocket-extension to 0.1.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,7 +77,7 @@ GEM
     haml (5.1.2)
       temple (>= 0.8.0)
       tilt
-    i18n (1.8.2)
+    i18n (1.8.3)
       concurrent-ruby (~> 1.0)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
@@ -150,7 +150,7 @@ GEM
       railties (>= 5.0)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
-    sassc (2.3.0)
+    sassc (2.4.0)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
       railties (>= 4.0.0)
@@ -164,7 +164,7 @@ GEM
       actionpack (>= 5.0)
       activemodel (>= 5.0)
     spring (2.1.0)
-    sprockets (4.0.0)
+    sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)
@@ -193,7 +193,7 @@ GEM
       railties (>= 5.0)
     websocket-driver (0.7.2)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.4)
+    websocket-extensions (0.1.5)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
Bumpimg websocket-extensions from 0.1.4 to 0.1.5 dependencies

1 websocket-extensions vulnerability found in Gemfile.lock 4

**Remediation**
Upgrade websocket-extensions to version 0.1.5 or later. For example:

```gem "websocket-extensions", ">= 0.1.5" - moderate severity```

Always verify the validity and compatibility of suggestions with your codebase.

**Details**
GHSA-g6wq-qcwm-j5g2

Vulnerable versions: < 0.1.5
Patched version: 0.1.5

**Impact**
The ReDoS flaw allows an attacker to exhaust the server's capacity to process
incoming requests by sending a WebSocket handshake request containing a header
of the following form:

```Sec-WebSocket-Extensions: a; b="\c\c\c\c\c\c\c\c\c\c ...```

That is, a header containing an unclosed string parameter value whose content is
a repeating two-byte sequence of a backslash and some other character. The
parser takes exponential time to reject this header as invalid, and this will
block the processing of any other work on the same thread. Thus if you are
running a single-threaded server, such a request can render your service
completely unavailable.

**Patches**
Users should upgrade to version 0.1.5.

**Workarounds**
There are no known work-arounds other than disabling any public-facing WebSocket functionality you are operating.

**References**
    ```https://blog.jcoglan.com/2020/06/02/redos-vulnerability-in-websocket-extensions/```

